### PR TITLE
Add a HID keyboard interface

### DIFF
--- a/build/gcc/Makefile
+++ b/build/gcc/Makefile
@@ -133,6 +133,9 @@ SRC = 		../../src/main.c                                         \
 			../../src/pwd-safe/HandleAesStorageKey.c	\
 			../../src/pwd-safe/password_safe.c	\
 
+# Keybi source files
+SRC += ../../src/keybi/usb.c
+
 			
 # List C source files here which must be compiled in ARM-Mode.
 # use file-extension c for "c-only"-files
@@ -191,6 +194,8 @@ EXTRAINCDIRS = ../../src/inc                                             \
 			   ../../src/stm/Libraries/STM32_USB-FS-Device_Driver/inc    \
 			   ../../src/stm/Libraries/STM32F10x_StdPeriph_Driver/inc
 
+# Keybi inc dir (allows to include keybi/header.h)
+EXTRAINCDIRS += ../../src
 
 # List any extra directories to look for library files here.
 #     Each directory must be seperated by a space.

--- a/build/gcc/Makefile
+++ b/build/gcc/Makefile
@@ -134,7 +134,8 @@ SRC = 		../../src/main.c                                         \
 			../../src/pwd-safe/password_safe.c	\
 
 # Keybi source files
-SRC += ../../src/keybi/usb.c
+SRC += ../../src/keybi/usb.c \
+       ../../src/keybi/keyboard.c
 
 			
 # List C source files here which must be compiled in ARM-Mode.

--- a/src/ccid/CCIDHID_USB/CCIDHID_usb_desc.c
+++ b/src/ccid/CCIDHID_USB/CCIDHID_usb_desc.c
@@ -183,7 +183,36 @@ const uint8_t CCID_ConfigDescriptor[CCID_SIZ_CONFIG_DESC] = {
     0x00,   // wMaxPacketSize (MSB)
     0x00,   // bInterval: ignored
 
+    // Interface 2 descriptor (HID Keyboard)
 
+    0x09,   // bLength               Descriptor size (9 bytes)
+    0x04,   // bDescriptorType       Descriptor type (interface)
+    0x02,   // bInterfaceNumber      Interface Number
+    0x00,   // bAlternateSetting     Alternate Setting Number (none)
+    0x01,   // bNumEndpoints         Number of endpoints
+    0x03,   // bInterfaceClass       Interface class (HID)
+    0x01,   // bInterfaceSubClass    Interface subclass (boot)
+    0x01,   // nInterfaceProtocol    Interface protocol (keyboard)
+    0x00,   // iInterface            Interface string index (none)
+
+    // Keyboard HID class descriptor
+
+    0x09,       // bLength           Descriptor size (9 bytes)
+    0x21,       // bDescriptorType   Descriptor type (HID)
+    0x10, 0x01, // bcdHID            HID release number (1.1)
+    0x00,       // bCountryCode      Hardware target country (not supported)
+    0x01,       // bNumDescriptors   Number class descriptors
+    0x22,       // bDescriptorType   Class descriptor type (report)
+    WBVAL (KEYBI_KEYBOARD_SIZ_REPORT_DESC),
+                // wItemLength       Report descriptor size
+
+    // Endpoint 5 descriptor
+    0x07,       // bLength           Descriptor size (7 bytes)
+    0x05,       // bDescriptorType   Descriptor type (endpoint)
+    0x85,       // bEndpointAddress  Endpoint 5 IN
+    0x03,       // bmAttributes      Transfer type (interrupt)
+    0x08, 0x00, // wMaxPacketSize    Maximum packet size (8 bytes)
+    0x0A        // bInterval         Polling interval
 };
 
 

--- a/src/ccid/CCIDHID_USB/CCIDHID_usb_prop.c
+++ b/src/ccid/CCIDHID_USB/CCIDHID_usb_prop.c
@@ -210,7 +210,7 @@ void USB_CCID_Reset (void)
 
     /* Initialize Endpoint 4 */
     SetEPType (ENDP4, EP_INTERRUPT);
-    SetEPTxAddr (ENDP4, ENDP4_TXADDR);
+    SetEPTxAddr (ENDP4, CCID_ENDP4_TXADDR);
     // SetEPTxCount(ENDP4, 8);
     SetEPRxStatus (ENDP4, EP_RX_DIS);
     SetEPTxStatus (ENDP4, EP_TX_NAK);

--- a/src/ccid/CCIDHID_USB/CCIDHID_usb_prop.c
+++ b/src/ccid/CCIDHID_USB/CCIDHID_usb_prop.c
@@ -215,6 +215,12 @@ void USB_CCID_Reset (void)
     SetEPRxStatus (ENDP4, EP_RX_DIS);
     SetEPTxStatus (ENDP4, EP_TX_NAK);
 
+    /* Initialize Endpoint 5 */
+    SetEPType (ENDP5, EP_INTERRUPT);
+    SetEPTxAddr (ENDP5, CCID_ENDP5_TXADDR);
+    SetEPRxStatus (ENDP5, EP_RX_DIS);
+    SetEPTxStatus (ENDP5, EP_TX_NAK);
+
     /* */
     SetEPRxCount (ENDP0, Device_Property->MaxPacketSize);
     SetEPRxValid (ENDP0);
@@ -249,6 +255,7 @@ void USB_CCID_Storage_SetConfiguration (void)
         ClearDTOG_TX (ENDP2);
         // ClearDTOG_TX(ENDP3);
         ClearDTOG_TX (ENDP4);
+        ClearDTOG_TX (ENDP5);
         Bot_State = BOT_IDLE;   /* set the Bot state machine to the IDLE state */
     }
 }
@@ -388,17 +395,25 @@ RESULT USB_CCID_Data_Setup (uint8_t RequestNo)
 uint8_t* (*CopyRoutine) (uint16_t);
 
     CopyRoutine = NULL;
-    if ((RequestNo == GET_DESCRIPTOR) && (Type_Recipient == (STANDARD_REQUEST | INTERFACE_RECIPIENT)) && (pInformation->USBwIndex0 == 0))
+    if ((RequestNo == GET_DESCRIPTOR) && (Type_Recipient == (STANDARD_REQUEST | INTERFACE_RECIPIENT)))
 
     {
 
         if (pInformation->USBwValue1 == REPORT_DESCRIPTOR)
         {
-            CopyRoutine = Keyboard_GetReportDescriptor;
+            if (pInformation->USBwIndex0 == 0) {
+                CopyRoutine = Keyboard_GetReportDescriptor;
+            } else if (pInformation->USBwIndex0 == 2) {
+                CopyRoutine = Keybi_Keyboard_GetReportDescriptor;
+            }
         }
         else if (pInformation->USBwValue1 == HID_DESCRIPTOR_TYPE)
         {
-            CopyRoutine = Keyboard_GetHIDDescriptor;
+            if (pInformation->USBwIndex0 == 0) {
+                CopyRoutine = Keyboard_GetHIDDescriptor;
+            } else if (pInformation->USBwIndex0 == 2) {
+                CopyRoutine = Keybi_Keyboard_GetHIDDescriptor;
+            }
         }
 
     }   /* End of GET_DESCRIPTOR */

--- a/src/inc/CCIDHID_usb_conf.h
+++ b/src/inc/CCIDHID_usb_conf.h
@@ -34,27 +34,30 @@
 /*-------------------------------------------------------------*/
 /* buffer table base address */
 
-#define BTABLE_ADDRESS      (0x00)
+#define BTABLE_ADDRESS           (0x00)
 
-/* EP0 */
-/* rx/tx buffer base address */
-#define CCID_ENDP0_RXADDR        (0x18)
-#define CCID_ENDP0_TXADDR        (0x58)
+// Entries in the Buffer Description Table describe each endpoint buffer location and size:
 
-/* EP1 */
-/* tx buffer base address */
-#define CCID_ENDP1_TXADDR        (0x98)
+// BTABLE_ADDRESS + EPn * 8 + 0: USB_ADDRn_TX  (TX buffer address inside the PMA)
+// BTABLE_ADDRESS + EPn * 8 + 2: USB_COUNTn_TX (bytes present in the TX buffer)
+// BTABLE_ADDRESS + EPn * 8 + 4: USB_ADDRn_RX  (RX buffer address inside the PMA)
+// BTABLE_ADDRESS + EPn * 8 + 6: USB_COUNTn_RX (bytes available/present for the RX buffer)
 
-/* EP2 */
-/* Rx buffer base address */
-#define CCID_ENDP2_RXADDR        (0xD8)
-/* Tx buffer base address */
-#define CCID_ENDP2_TXADDR        (0x118)
+// EP0, size = 64
+#define CCID_ENDP0_RXADDR        (0x40) // BTABLE_ADDRESS + BTABLE max size (64)
+#define CCID_ENDP0_TXADDR        (0x80)
 
-/* EP3 */
-/* tx buffer base address */
-// #define ENDP3_TXADDR (0x158)
-#define ENDP4_TXADDR        (0x19C)
+// EP1, size = 64 (needs to be checked, found nothing using over 4 bytes in code)
+#define CCID_ENDP1_TXADDR        (0xC0)
+
+// EP2, size = 64
+#define CCID_ENDP2_RXADDR        (0x100)
+#define CCID_ENDP2_TXADDR        (0x140)
+
+// EP4, size = 8
+#define CCID_ENDP4_TXADDR        (0x180)
+
+// PMA size is 512 bytes, last buffer address + size must be < 0x200
 
 /* ISTR events */
 /* IMR_MSK */

--- a/src/inc/CCIDHID_usb_conf.h
+++ b/src/inc/CCIDHID_usb_conf.h
@@ -27,7 +27,7 @@
 /* EP_NUM */
 /* defines how many endpoints are used by the device */
 /*-------------------------------------------------------------*/
-#define CCID_EP_NUM                          (5)
+#define CCID_EP_NUM                          (6)
 
 /*-------------------------------------------------------------*/
 /* -------------- Buffer Description Table ----------------- */
@@ -56,6 +56,9 @@
 
 // EP4, size = 8
 #define CCID_ENDP4_TXADDR        (0x180)
+
+// EP5, size = 8
+#define CCID_ENDP5_TXADDR        (0x188)
 
 // PMA size is 512 bytes, last buffer address + size must be < 0x200
 

--- a/src/inc/CCIDHID_usb_desc.h
+++ b/src/inc/CCIDHID_usb_desc.h
@@ -25,12 +25,13 @@
 
 /* Includes ------------------------------------------------------------------ */
 #include "stm32f10x.h"
+#include "keybi/usb.h"
 /* Exported types ------------------------------------------------------------ */
 /* Exported constants -------------------------------------------------------- */
 /* Exported macro ------------------------------------------------------------ */
 /* Exported define ----------------------------------------------------------- */
 #define CCID_SIZ_DEVICE_DESC              18
-#define CCID_SIZ_CONFIG_DESC              (1*0x09 + 2*0x09+ 1*0x07+ 0x09 + 0x36+3*0x07)
+#define CCID_SIZ_CONFIG_DESC              (1*0x09 + 2*0x09+ 1*0x07+ 0x09 + 0x36+3*0x07 + 25)
 // #define CCID_SIZ_CONFIG_DESC (1*0x09 + 3*0x09 +0x36 + 4*0x07)
 // #define CCID_SIZ_CONFIG_DESC (3*0x09 +2*0x36 + 6*0x07)
 

--- a/src/inc/usb_conf.h
+++ b/src/inc/usb_conf.h
@@ -27,7 +27,7 @@
 /* EP_NUM */
 /* defines how many endpoints are used by the device */
 /*-------------------------------------------------------------*/
-#define EP_NUM                          (5)
+#define EP_NUM                          (6)
 
 /*-------------------------------------------------------------*/
 /* -------------- Buffer Description Table ----------------- */
@@ -72,7 +72,7 @@
 // #define EP2_IN_Callback NOP_Process
 #define  EP3_IN_Callback   NOP_Process
 // #define EP4_IN_Callback NOP_Process
-#define  EP5_IN_Callback   NOP_Process
+// #define  EP5_IN_Callback   NOP_Process
 #define  EP6_IN_Callback   NOP_Process
 #define  EP7_IN_Callback   NOP_Process
 

--- a/src/keybi/keyboard.c
+++ b/src/keybi/keyboard.c
@@ -1,0 +1,55 @@
+#include "keybi/keyboard.h"
+
+#include "usb_pwr.h"
+#include "usb_mem.h"
+#include "usb_regs.h"
+#include "CCIDHID_usb_conf.h"
+
+void Keybi_Keyboard_Init(void) {
+
+    // Use the Nucleo user button as the only keyboard switch for now
+
+    GPIO_InitTypeDef GPIO_InitStructure;
+
+    RCC_APB2PeriphClockCmd (NUCLEO_BTN_PERIPH, ENABLE);
+
+    GPIO_InitStructure.GPIO_Pin = NUCLEO_BTN_PIN;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IPU;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_Init(NUCLEO_BTN_PIN_PORT, &GPIO_InitStructure);
+}
+
+extern __IO uint8_t keybi_keyboard_prev_xfer_complete;
+
+void Keybi_Keyboard_SendReport(uint8_t * report);
+
+void Keybi_Keyboard_SendReport(uint8_t * report) {
+
+    if (bDeviceState == CONFIGURED)
+    {
+        while (!keybi_keyboard_prev_xfer_complete);
+
+        keybi_keyboard_prev_xfer_complete = 0;
+        /* Use the memory interface function to write to the selected endpoint */
+        UserToPMABufferCopy(report, CCID_ENDP5_TXADDR, 8);
+
+        /* Update the data length in the control register */
+        SetEPTxCount(ENDP5, 8);
+        SetEPTxStatus(ENDP5, EP_TX_VALID);
+    }
+}
+
+void Keybi_Keyboard_MainLoop(void)
+{
+    static uint8_t prev_switch_pressed = 0;
+    uint8_t switch_pressed = !GPIO_ReadInputDataBit(NUCLEO_BTN_PIN_PORT, NUCLEO_BTN_PIN);
+
+    static uint8_t report[8] = {0};
+    if (switch_pressed && !prev_switch_pressed) {
+        report[2] = 'a' - 93;
+        Keybi_Keyboard_SendReport(report);
+        report[2] = 0;
+        Keybi_Keyboard_SendReport(report);
+    }
+    prev_switch_pressed = switch_pressed;
+}

--- a/src/keybi/keyboard.h
+++ b/src/keybi/keyboard.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "stm32f10x.h"
+
+#define NUCLEO_BTN_PERIPH     RCC_APB2Periph_GPIOC
+#define NUCLEO_BTN_PIN_PORT   GPIOC
+#define NUCLEO_BTN_PIN        GPIO_Pin_13
+
+void Keybi_Keyboard_Init(void);
+void Keybi_Keyboard_MainLoop(void);

--- a/src/keybi/usb.c
+++ b/src/keybi/usb.c
@@ -1,0 +1,81 @@
+#include "keybi/usb.h"
+
+#include "usb_core.h"
+#include "CCIDHID_usb_desc.h"
+
+const uint8_t Keybi_Keyboard_ReportDescriptor[KEYBI_KEYBOARD_SIZ_REPORT_DESC] = {
+    0x05, 0x01, // USAGE_PAGE (Generic Desktop)
+    0x09, 0x06, // USAGE (Keyboard)
+
+    0xa1, 0x01, // COLLECTION (Application)
+
+    // Modifier byte
+    0x05, 0x07, // USAGE_PAGE (Keyboard)
+    0x19, 0xe0, // USAGE_MINIMUM (Keyboard LeftControl)
+    0x29, 0xe7, // USAGE_MAXIMUM (Keyboard Right GUI)
+    0x15, 0x00, // LOGICAL_MINIMUM (0)
+    0x25, 0x01, // LOGICAL_MAXIMUM (1)
+    0x75, 0x01, // REPORT_SIZE (1)
+    0x95, 0x08, // REPORT_COUNT (8)
+    0x81, 0x02, // INPUT (Data,Var,Abs)
+
+    // Reserved byte
+    0x95, 0x01, // REPORT_COUNT (1)
+    0x75, 0x08, // REPORT_SIZE (8)
+    0x81, 0x03, // INPUT (Cnst,Var,Abs) (0x81, 0x01 constant in HID class definition example)
+
+    // LED report
+    0x95, 0x05, // REPORT_COUNT (5)
+    0x75, 0x01, // REPORT_SIZE (1)
+    0x05, 0x08, // USAGE_PAGE (LEDs)
+    0x19, 0x01, // USAGE_MINIMUM (Num Lock)
+    0x29, 0x05, // USAGE_MAXIMUM (Kana)
+    0x91, 0x02, // OUTPUT (Data,Var,Abs)
+
+    // LED report padding
+    0x95, 0x01, // REPORT_COUNT (1)
+    0x75, 0x03, // REPORT_SIZE (3)
+    0x91, 0x03, // OUTPUT (Cnst,Var,Abs)
+
+    // Key arrays (6 bytes)
+    0x95, 0x06, // REPORT_COUNT (6)
+    0x75, 0x08, // REPORT_SIZE (8)
+    0x15, 0x00, // LOGICAL_MINIMUM (0)
+    0x25, 0x65, // LOGICAL_MAXIMUM (101)
+    0x05, 0x07, // USAGE_PAGE (Key codes)
+    0x19, 0x00, // USAGE_MINIMUM (Reserved (no event indicated))
+    0x29, 0x65, // USAGE_MAXIMUM (Keyboard Application)
+    0x81, 0x00, // INPUT (Data,Ary,Abs)
+
+    0xc0   // END_COLLECTION
+};
+
+// used in usb_endp.c
+
+__IO uint8_t keybi_keyboard_prev_xfer_complete = 1;
+
+void Keybi_Keyboard_SendReportCompleted(void) {
+    keybi_keyboard_prev_xfer_complete = 1;
+}
+
+// used in CCIDHID_usb_prop.c
+
+ONE_DESCRIPTOR Keybi_Keyboard_Report_Descriptor = {
+    (uint8_t *) Keybi_Keyboard_ReportDescriptor,
+    KEYBI_KEYBOARD_SIZ_REPORT_DESC
+};
+
+ONE_DESCRIPTOR Keybi_Keyboard_Hid_Descriptor = {
+    (uint8_t *) CCID_ConfigDescriptor + KEYBI_KEYBOARD_KEYBOARD_OFF_HID_DESC,
+    KEYBI_KEYBOARD_SIZ_HID_DESC
+};
+
+uint8_t* Keybi_Keyboard_GetReportDescriptor(uint16_t Length)
+{
+    return Standard_GetDescriptorData(Length, &Keybi_Keyboard_Report_Descriptor);
+}
+
+uint8_t* Keybi_Keyboard_GetHIDDescriptor(uint16_t Length)
+{
+    return Standard_GetDescriptorData(Length, &Keybi_Keyboard_Hid_Descriptor);
+}

--- a/src/keybi/usb.h
+++ b/src/keybi/usb.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "stm32f10x.h"
+
+#define KEYBI_KEYBOARD_SIZ_HID_DESC           (0x09)
+#define KEYBI_KEYBOARD_SIZ_REPORT_DESC          (63)
+#define KEYBI_KEYBOARD_KEYBOARD_OFF_HID_DESC   (121)
+
+uint8_t* Keybi_Keyboard_GetReportDescriptor(uint16_t Length);
+
+uint8_t* Keybi_Keyboard_GetHIDDescriptor(uint16_t Length);
+
+void Keybi_Keyboard_SendReportCompleted(void);

--- a/src/keyboard/keyboard.c
+++ b/src/keyboard/keyboard.c
@@ -23,7 +23,7 @@
 #include "usb_lib.h"
 #include "hw_config.h"
 #include "usb_pwr.h"
-#include "CCID_usb.h"
+#include "CCIDHID_usb_conf.h"
 #include "keyboard.h"
 #include "AccessInterface.h"
 #include "hotp.h"
@@ -82,7 +82,7 @@ void sendKeys (uint8_t * buffer)
 
         PrevXferComplete = 0;
         /* Use the memory interface function to write to the selected endpoint */
-        UserToPMABufferCopy (buffer, ENDP4_TXADDR, 8);
+        UserToPMABufferCopy (buffer, CCID_ENDP4_TXADDR, 8);
 
         /* Update the data length in the control register */
         SetEPTxCount (ENDP4, 8);

--- a/src/main.c
+++ b/src/main.c
@@ -36,6 +36,8 @@
 #include "CcidLocalAccess.h"
 #include "HandleAesStorageKey.h"
 
+#include "keybi/keyboard.h"
+
 
 int nGlobalStickState = STICK_STATE_SMARTCARD;
 
@@ -117,6 +119,8 @@ int main(void) {
 
   StartupCheck_u8();
 
+  Keybi_Keyboard_Init();
+
   /* Endless loop after USB startup */
   while (1) {
     if (device_status == STATUS_RECEIVED_REPORT) {
@@ -149,6 +153,7 @@ int main(void) {
       nFlagSendSMCardInserted = FALSE;
     }
 
+    Keybi_Keyboard_MainLoop();
   }
 }
 

--- a/src/usb/usb_endp.c
+++ b/src/usb/usb_endp.c
@@ -25,7 +25,8 @@
 #include "usb_istr.h"
 
 #include "platform_config.h"
-#include "CCID_usb.h"
+#include "CCIDHID_usb.h"
+#include "keybi/usb.h"
 
 /* Private typedef ----------------------------------------------------------- */
 /* Private define ------------------------------------------------------------ */
@@ -98,4 +99,9 @@ void EP4_IN_Callback (void)
     /* Set the transfer complete token to inform upper layer that the current transfer has been complete */
     PrevXferComplete = 1;
     // SwitchSmartcardLED(DISABLE);
+}
+
+void EP5_IN_Callback (void)
+{
+    Keybi_Keyboard_SendReportCompleted();
 }


### PR DESCRIPTION
Send 'A' keypresses using the Nucleo evaluation board.

Tested that the host handles the keypresses and still manage to access the smartcard with `gpg --card-status`.